### PR TITLE
Mark the automatic publication as ready

### DIFF
--- a/lib/server/presence.coffee
+++ b/lib/server/presence.coffee
@@ -47,6 +47,7 @@ Meteor.publish null, ->
       loginToken: hashedToken
       userId: @userId
       lastSeen: new Date()
+  @ready()
   return
 
 # allow the client to provide stateful information about itself


### PR DESCRIPTION
This fixes a bug when both `3stack:presence` and `meteorhacks:fast-render` are added on the same application.

See https://github.com/kadirahq/fast-render/issues/146#issuecomment-152364747 for more details.